### PR TITLE
Get layer height and extrusion multiplier from environment variables

### DIFF
--- a/bricklayers.py
+++ b/bricklayers.py
@@ -130,14 +130,18 @@ def process_gcode(input_file, layer_height, extrusion_multiplier):
 
 # Main execution
 if __name__ == "__main__":
+
     parser = argparse.ArgumentParser(description="Post-process G-code for Z-shifting and extrusion adjustments.")
     parser.add_argument("input_file", help="Path to the input G-code file")
-    parser.add_argument("-layerHeight", type=float, default=0.2, help="Layer height in mm (default: 0.2mm)")
-    parser.add_argument("-extrusionMultiplier", type=float, default=1, help="Extrusion multiplier for first layer (default: 1.5x)")
+    parser.add_argument("-layerHeight", type=float, default=None, help="Layer height in mm (default: 0.2mm)")
+    parser.add_argument("-extrusionMultiplier", type=float, default=None, help="Extrusion multiplier for first layer (default: 1.5x)")
     args = parser.parse_args()
+
+    layerHeight = args.layerHeight or float(os.environ.get('SLIC3R_Layer_height', 0.2))
+    extrusionMultiplier = args.extrusionMultiplier or float(os.environ.get('SLIC3R_Extrusion_multiplier', 1.5))
 
     process_gcode(
         input_file=args.input_file,
-        layer_height=args.layerHeight,
-        extrusion_multiplier=args.extrusionMultiplier,
+        layer_height=layerHeight,
+        extrusion_multiplier=extrusionMultiplier,
     )


### PR DESCRIPTION
PrusaSlicer sets some environment variables when running postprocessing scripts. We can get the layer height and extrusion multiplier directly from these.

See [PrusaSlicer docs](https://help.prusa3d.com/article/post-processing-scripts_283913).