### PR TITLE
Update README.md with External Perimeters First option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Sample:
 
 ```"C:\Your\Path\To\Python\python.exe" "C:\Your\Path\To\Script\bricklayers.py" -layerheight 0.2 -extrusionMultiplier 1.3```
 
+For best results, please enable the 'External Perimeters First' option in your slicer
+
 Thanks to all of you who opened issues and made pullrequests. I'm not ignoring you, I just didn't have the time to review yet. I will do on the weekend!<3
 (I will also make a good readme then)
 


### PR DESCRIPTION
In README.md I've added a paragraph about enabling the 'External Perimeters First' option for the best results, as mentioned in the discussion in issue #16:
