### PR TITLE
Fix non-planar interlocking walls script scaling_factor definition causing error 1

### DIFF
--- a/NonPlanarInterlockingWalls.py
+++ b/NonPlanarInterlockingWalls.py
@@ -342,7 +342,7 @@ def process_gcode(
 
                 # compute per‑segment extrusion and modulation
                 extrusion_per_seg = e_total / (len(segments) - 1)
-                scaling = calculate_scaling_factor(
+                scaling_factor = calculate_scaling_factor(
                     current_z, last_bottom_layer, next_top_layer, max_step_size
                 )
                 # pick your amp/freq/direction based on region…


### PR DESCRIPTION
Fixed possible typo in NonPlanarInterlockingWalls.py — **scaling_factor** was supposed to be defined in line 345, but '_factor' was left off. (This was causing error 1 at line 375, which was trying to use the undefined **scaling_factor** variable.)