### PR TITLE
NonPlanarInterlockingWalls fix logging permissions issue on Windows

### DIFF
--- a/NonPlanarInterlockingWalls.py
+++ b/NonPlanarInterlockingWalls.py
@@ -17,6 +17,7 @@ import math
 import sys
 import logging
 import argparse
+import os
 from collections import Counter
 
 def sine_wave(x):

--- a/NonPlanarInterlockingWalls.py
+++ b/NonPlanarInterlockingWalls.py
@@ -75,13 +75,16 @@ PERIODIC_FUNCTIONS = {
     "sawtooth": sawtooth_wave
 }
 
+# Get the directory where the script is located
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Configure logging to save in the script's directory
+log_file_path = os.path.join(script_dir, "NPIW_gcode_debug.log")
 logging.basicConfig(
+    filename=log_file_path,
+    filemode="w",
     level=logging.DEBUG,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("gcode_debug.log"),
-        logging.StreamHandler(sys.stdout)
-    ]
+    format="%(asctime)s - %(message)s"
 )
 
 DEFAULT_AMPLITUDE = 0.3


### PR DESCRIPTION
I found through running PrusaSlicer in console mode (via cmd, `c:\Program Files\Prusa3D\PrusaSlicer\prusa-slicer-console.exe`) that `Error code 1`  everyone seems to be getting with `NonPlanarInterlockingWalls.py` is indeed a permissions issue:

```
Traceback (most recent call last):
  File "C:\Program Files\Prusa3D\PrusaSlicer\NonPlanarInterlockingWalls.py", line 82, in <module>
    logging.FileHandler("gcode_debug.log"),
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python313\Lib\logging\__init__.py", line 1218, in __init__
    StreamHandler.__init__(self, self._open())
                                 ~~~~~~~~~~^^
  File "C:\Program Files\Python313\Lib\logging\__init__.py", line 1247, in _open
    return open_func(self.baseFilename, self.mode,
                     encoding=self.encoding, errors=self.errors)
PermissionError: [Errno 13] Permission denied: 'c:\\Program Files\\Prusa3D\\PrusaSlicer\\gcode_debug.log'
```

While running your slicer as administrator should fix this, I was curious why the other scripts weren't affected.

Turns out, the problem is with the [logging configuration](https://github.com/TengerTechnologies/Bricklayers/blob/ef361d0a733a23e4aeda074c0b2e3cf2d679f1f5/NonPlanarInterlockingWalls.py#L82). When the slicer calls the post-processing script, it tries to write to the directory of the slicer executable. On Windows, if the slicer was installed "for all users", that directory ends up in `C:\Program Files` (or similar), which is protected. Changing the target directory fixes the issue. I opted just to replicate what was done in the other scripts, though I left the logging level set to `DEBUG`